### PR TITLE
feat(backend): add week summary endpoint

### DIFF
--- a/backend/src/app/handlers/get-week-summary.ts
+++ b/backend/src/app/handlers/get-week-summary.ts
@@ -1,0 +1,79 @@
+import { between, desc, eq, lte, sql } from 'drizzle-orm'
+
+import db from '@/db'
+import { goalCompletions, goals } from '@/db/schema'
+
+export default async function getWeekSummaryHandler() {
+  const firstDayOfWeek = new Date()
+  firstDayOfWeek.setDate(firstDayOfWeek.getDate() - firstDayOfWeek.getDay())
+  firstDayOfWeek.setHours(0, 0, 0, 0)
+  const lastDayOfWeek = new Date(firstDayOfWeek)
+  lastDayOfWeek.setDate(lastDayOfWeek.getDate() + 6)
+  lastDayOfWeek.setHours(23, 59, 59, 999)
+
+  const goalsCreatedUpToThisWeek = db.$with('goals_created_up_to_this_week').as(
+    db
+      .select({
+        id: goals.id,
+        title: goals.title,
+        desiredWeeklyFrequency: goals.desiredWeeklyFrequency,
+        createAt: goals.createdAt,
+      })
+      .from(goals)
+      .where(lte(goals.createdAt, lastDayOfWeek))
+  )
+
+  const goalsCompletedThisWeek = db.$with('goals_completed_this_week').as(
+    db
+      .select({
+        goalId: goalCompletions.id,
+        title: goals.title,
+        completedAt: goalCompletions.createdAt,
+        completedOn: sql`DATE(${goalCompletions.createdAt})`.as('completedOn'),
+      })
+      .from(goalCompletions)
+      .innerJoin(goals, eq(goalCompletions.goalId, goals.id))
+      .where(between(goalCompletions.createdAt, firstDayOfWeek, lastDayOfWeek))
+      .orderBy(desc(goalCompletions.createdAt))
+  )
+
+  const goalsCompletedByDay = db.$with('goals_completed_by_day').as(
+    db
+      .select({
+        completedOn: goalsCompletedThisWeek.completedOn,
+        completions: sql`
+          JSON_AGG(
+            JSON_BUILD_OBJECT(
+              'id', ${goalsCompletedThisWeek.goalId},
+              'title', ${goalsCompletedThisWeek.title},
+              'completedAt', ${goalsCompletedThisWeek.completedAt}
+            )
+          )
+          `.as('completions'),
+      })
+      .from(goalsCompletedThisWeek)
+      .groupBy(goalsCompletedThisWeek.completedOn)
+      .orderBy(desc(goalsCompletedThisWeek.completedOn))
+  )
+
+  const summary = await db
+    .with(goalsCreatedUpToThisWeek, goalsCompletedThisWeek, goalsCompletedByDay)
+    .select({
+      completed: sql`(SELECT COUNT(*) FROM ${goalsCompletedThisWeek})`.mapWith(
+        Number
+      ),
+      total:
+        sql`(SELECT SUM(${goalsCreatedUpToThisWeek.desiredWeeklyFrequency}) FROM ${goalsCreatedUpToThisWeek})`.mapWith(
+          Number
+        ),
+      goalsCompletedByDay: sql`
+        JSON_OBJECT_AGG(
+          ${goalsCompletedByDay.completedOn},
+          ${goalsCompletedByDay.completions}
+        )
+      `,
+    })
+    .from(goalsCompletedByDay)
+
+  return { summary }
+}

--- a/backend/src/http/routes/get-week-summary.ts
+++ b/backend/src/http/routes/get-week-summary.ts
@@ -1,0 +1,11 @@
+import type { FastifyPluginAsyncZod } from 'fastify-type-provider-zod'
+
+import getWeekSummaryHandler from '@/app/handlers/get-week-summary'
+
+const getWeekSummaryRoute: FastifyPluginAsyncZod = async app => {
+  app.get('/summary', {}, async () => {
+    return await getWeekSummaryHandler()
+  })
+}
+
+export default getWeekSummaryRoute

--- a/backend/src/http/server.ts
+++ b/backend/src/http/server.ts
@@ -8,6 +8,7 @@ import {
 import env from '@/config/env'
 import createGoalRoute from './routes/create-goal'
 import createGoalCompletionRoute from './routes/create-goal-completion'
+import getWeekSummaryRoute from './routes/get-week-summary'
 import listWeekPendingGoalsRoute from './routes/list-week-pending-goals'
 
 const app = fastify()
@@ -18,6 +19,7 @@ app.withTypeProvider<ZodTypeProvider>()
 
 app.register(createGoalRoute)
 app.register(createGoalCompletionRoute)
+app.register(getWeekSummaryRoute)
 app.register(listWeekPendingGoalsRoute)
 
 app.listen({ host: env.HOST, port: env.PORT }, (err, address) => {


### PR DESCRIPTION
Implement new API endpoint to retrieve weekly goal summary
- Create handler to fetch and process weekly goal data
- Add new route for /summary endpoint
- Register new route in server configuration

This feature provides users with an overview of their weekly goal
progress, including completed goals and completion rates.
